### PR TITLE
create recommended rules

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+./node_modules/
+

--- a/README.md
+++ b/README.md
@@ -12,20 +12,21 @@ Some rules intend to warn you of [potential footguns][PillarsOfJS].
 You'll first need to install [ESLint]:
 
 ```
-$ npm i eslint --save-dev
+$ npm install --save-dev eslint
 ```
 
 Next, install `@br/eslint-plugin-laws-of-the-game`:
 
 ```
-$ npm install @br/eslint-plugin-laws-of-the-game --save-dev
+$ npm install --save-dev @br/eslint-plugin-laws-of-the-game
 ```
 
 **Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `@br/eslint-plugin-laws-of-the-game` globally.
 
+
 ## Usage
 
-Add `@br/laws-of-the-game` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+Add `"@br/laws-of-the-game"` to the `plugins` section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
 
 ```json
 {
@@ -45,7 +46,7 @@ It's Recommended that you use the Recommended set of rules (which is all of them
 }
 ```
 
-Then configure the rules you want to use under the rules section.
+Then configure any rules you'd like to tweak under the `rules` section:
 
 ```json
 {
@@ -55,6 +56,7 @@ Then configure the rules you want to use under the rules section.
     }
 }
 ```
+
 
 ## Supported Rules
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
     "rules": {
-        "laws-of-the-game/alphabetize-properties": [2, {"limit": 3}],
-        "laws-of-the-game/no-assign-process-dot-env": 2
+        "@br/laws-of-the-game/alphabetize-properties": [2, {"limit": 3}],
+        "@br/laws-of-the-game/no-assign-in-case-without-braces": 1
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Add `@br/laws-of-the-game` to the plugins section of your `.eslintrc` configurat
 }
 ```
 
+It's Recommended that you use the Recommended set of rules (which is all of them), by adding to the `extends` section:
+
+```json
+{
+    "extends": [
+        "plugin:@br/laws-of-the-game/recommended",
+    ]
+}
+```
 
 Then configure the rules you want to use under the rules section.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,17 @@ var requireIndex = require("requireindex");
 
 
 // import all rules in lib/rules
-module.exports.rules = requireIndex(__dirname + "/rules");
-
-
-
+module.exports = {
+  rules: requireIndex(__dirname + "/rules"),
+  configs: {
+    recommended: {
+      rules: {
+        "@br/laws-of-the-game/alphabetize-properties": "error",
+        "@br/laws-of-the-game/no-assign-in-case-without-braces": "error",
+        "@br/laws-of-the-game/no-unauthorized-global-properties": "error",
+        "@br/laws-of-the-game/no-use-entire-process-dot-env": "error",
+        "@br/laws-of-the-game/prefer-includes-over-indexof": "error"
+      }
+    }
+  }
+};


### PR DESCRIPTION
The recommended set of rules (i.e. all of them set to errors) can be used in other projects by specifying this plugin in the ESLint config `extends` array, e.g.:

```json
"extends": [
  "plugin:@br/laws-of-the-game/recommended",
]
```

The recommended rules can be overridden by specifying them normally in the ESLint config, e.g.:

```json
"rules": {
  "@br/laws-of-the-game/no-assign-in-case-without-braces": 1
}
```

resolves #11 