### PR TITLE
alphabetize rule should cover exports as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.ignore
+++ b/.ignore
@@ -1,1 +1,1 @@
-node_modules/
+node_modules

--- a/.ignore
+++ b/.ignore
@@ -1,2 +1,1 @@
-./node_modules/
-
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning].
 
 
+## [unreleased] (2018-10-23)
+
+### Changed
+- `alphabetize-properties` rule applies to `export` statement.
+
+
 ## [1.3.0] (2018-04-27)
 
 ### Added
-- Many (non-custom) rules from ESLint, `eslint-plugin-babel`, and `eslint-plugin-react` to the Recommended Ruleset.
+- Many (non-custom) rules from ESLint, `eslint-plugin-babel`, and `eslint-plugin-react`.
 
 
 ## [1.2.0] (2018-03-23)
 
 ### Added
-- Recommended Ruleset
+- Recommended ruleset
 
 
 ## [1.1.1] (2017-06-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 ## [1.3.0] (2018-04-27)
 
 ### Added
-- Many (non-custom) rules from ESLint, `eslint-plugin-babel`, and `eslint-plugin-react`.
+- Many (non-custom) rules from ESLint, `eslint-plugin-babel`, and `eslint-plugin-react` to the Recommended Ruleset.
 
 
 ## [1.2.0] (2018-03-23)
 
 ### Added
-- Recommended ruleset
+- Recommended Ruleset
 
 
 ## [1.1.1] (2017-06-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning].
 
 
-## [unreleased] (2018-10-23)
+## unreleased (2018-10-23)
 
 ### Changed
 - `alphabetize-properties` rule applies to `export` statement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 ## [1.3.0] (2018-04-27)
 
 ### Added
-- Many (non-custom) rules from ESLint, `eslint-plugin-babel`, and `eslint-plugin-react`.
+- Many (non-custom) rules from ESLint, `eslint-plugin-babel`, and `eslint-plugin-react` to the Recommended Ruleset.
 
 
 ## [1.2.0] (2018-03-23)
 
 ### Added
-- Recommended ruleset
+- Recommended Ruleset
 
 
 ## [1.1.1] (2017-06-01)

--- a/README.md
+++ b/README.md
@@ -75,9 +75,13 @@ Then configure any rules you'd like to tweak under the `rules` section:
 ## Contributions
 
 We welcome contributions!
-There are a few ideas in the Issues of this repo.
+There are a few ideas in the [Issues] of this repo.
+
+To get started with how to lint JavaScript, play around with the [AST Explorer].
+
 We use a form of [git-flow]; please create any Pull Requests based on the `develop` branch.
-Please add tests.
+
+Please add tests!
 
 
 
@@ -87,6 +91,8 @@ Please add tests.
 [no-unauthorized-global-properties]: ./lib/rules/no-unauthorized-global-properties.md
 [no-use-entire-process-dot-env]: ./lib/rules/no-use-entire-process-dot-env.md
 [prefer-includes-over-indexof]: ./lib/rules/prefer-includes-over-indexof.md
+[AST Explorer]: https://astexplorer.net/
 [ESLint]: http://eslint.org
+[Issues]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/issues
 [PillarsOfJS]: https://medium.com/javascript-scene/the-two-pillars-of-javascript-ee6f3281e7f3
 [Process-dot-env]: https://nodejs.org/api/process.html#process_process_env

--- a/README.md
+++ b/README.md
@@ -86,7 +86,15 @@ Please add tests!
 
 ## Release Process
 
-Please use `npm publish` to release new versions of this package. This codebase attempts to follow [Semantic Versioning].
+This codebase attempts to follow [Semantic Versioning].
+
+1. One or more *approved* Pull Requests are merged to the `master` branch.
+2. Ensure the test suite passes, and runs the expected number of tests: `npm test`
+3. Choose the appropriate New Version Number according to [Semantic Versioning]. (The `CHANGELOG.md` file may help with identifying the nature of the changes.)
+4. Edit the `CHANGELOG.md` file, replacing the "Unreleased" label with the New Version Number, linked to the (as-yet-uncreated) GitHub tag as well (the pattern is `https://github.com/<user>/<repo>/releases/tag/<version-number>`). Ensure that the notes under this version reflect the changes made by the merged Pull Requests.
+5. Run `npm version <version-number> --message "Version %s"` to both update the version in the `package.json` file and create the tag on GitHub.
+6. Run `git push && npm publish` to push the merges & version to GitHub, and publish the new package on npmjs.com.
+
 
 
 
@@ -95,6 +103,7 @@ Please use `npm publish` to release new versions of this package. This codebase 
 [no-assign-in-case-without-braces]: ./lib/rules/no-assign-in-case-without-braces.md
 [no-unauthorized-global-properties]: ./lib/rules/no-unauthorized-global-properties.md
 [no-use-entire-process-dot-env]: ./lib/rules/no-use-entire-process-dot-env.md
+[npm version]: https://docs.npmjs.com/getting-started/publishing-npm-packages#how-to-update-a-package
 [prefer-includes-over-indexof]: ./lib/rules/prefer-includes-over-indexof.md
 [AST Explorer]: https://astexplorer.net/
 [ESLint]: http://eslint.org

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ Please add tests!
 This codebase attempts to follow [Semantic Versioning].
 
 1. One or more *approved* Pull Requests are merged to the `master` branch.
-2. Ensure the test suite passes, and runs the expected number of tests: `npm test`
-3. Choose the appropriate New Version Number according to [Semantic Versioning]. (The `CHANGELOG.md` file may help with identifying the nature of the changes.)
-4. Edit the `CHANGELOG.md` file, replacing the "Unreleased" label with the New Version Number, linked to the (as-yet-uncreated) GitHub tag as well (the pattern is `https://github.com/<user>/<repo>/releases/tag/<version-number>`). Ensure that the notes under this version reflect the changes made by the merged Pull Requests.
-5. Run `npm version <version-number> --message "Version %s"` to both update the version in the `package.json` file and create the tag on GitHub.
-6. Run `git push && npm publish` to push the merges & version to GitHub, and publish the new package on npmjs.com.
+1. Ensure the test suite passes, and runs the expected number of tests: `npm test`
+1. Choose the appropriate New Version Number according to [Semantic Versioning]. (The `CHANGELOG.md` file may help with identifying the nature of the changes.)
+1. Edit the `CHANGELOG.md` file, replacing the "Unreleased" label with the New Version Number, linked to the (as-yet-uncreated) GitHub tag as well (the pattern is `https://github.com/<user>/<repo>/releases/tag/<version-number>`). Ensure that the notes under this version reflect the changes made by the merged Pull Requests.
+1. Run `npm version <version-number> --message "Version %s"` to both update the version in the `package.json` file and create the tag on GitHub.
+1. Run `git push && npm publish` to push the merges & version to GitHub, and publish the new package on npmjs.com.
 
 
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ We use a form of [git-flow]; please create any Pull Requests based on the `devel
 Please add tests!
 
 
+## Release Process
+
+Please use `npm publish` to release new versions of this package. This codebase attempts to follow [Semantic Versioning].
+
+
 
 [alphabetize-properties]: ./lib/rules/alphabetize-properties.md
 [git-flow]: http://nvie.com/posts/a-successful-git-branching-model/
@@ -96,3 +101,4 @@ Please add tests!
 [Issues]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/issues
 [PillarsOfJS]: https://medium.com/javascript-scene/the-two-pillars-of-javascript-ee6f3281e7f3
 [Process-dot-env]: https://nodejs.org/api/process.html#process_process_env
+[Semantic Versioning]: https://semver.org/spec/v2.0.0.html

--- a/lib/rules/alphabetize-properties.js
+++ b/lib/rules/alphabetize-properties.js
@@ -20,6 +20,10 @@ function extractKey(objectProperty) {
   return objectProperty.key.name;
 }
 
+function extractName(exportSpecifier) {
+  return exportSpecifier.local.name;
+}
+
 module.exports = {
   esLintRuleName: "alphabetize-properties-of-large-objects",
   schema: [
@@ -49,9 +53,25 @@ module.exports = {
       throw new Error("Value of `exempt` option must be an array of strings (key names); saw a: " + typeof exemptions);
     }
     var removeExemptions = makeExemptionsFilter(exemptions);
+    function checkExport(node) {
+      if (!node.specifiers.length) {
+        return;
+      }
+      var rawExportNames = node.specifiers.map(extractName);
+      if (rawExportNames.length < limit) {
+        return;
+      }
+      var exportNames = rawExportNames.filter(removeExemptions);
+      function isKeyOutOfOrder(key, index) {
+        // TODO control sorting order?
+        return index !== 0 && key < exportNames[index-1];
+      }
+      if (exportNames.find(isKeyOutOfOrder)) {
+        context.report({message: "Exports with "+limit+" or more specifiers should have specifiers in alphabetical order. (Saw "+rawExportNames.length+")", node: node});
+      }
+    }
     function checkObject(node) {
       if (!node.properties.length) {
-        // somewhat-earlier exit...
         return;
       }
       var rawPropertyKeys = node.properties.filter(isStandardProperty).map(extractKey);
@@ -63,12 +83,12 @@ module.exports = {
         // TODO control sorting order?
         return index !== 0 && key < propertyKeys[index-1];
       }
-
       if (propertyKeys.find(isKeyOutOfOrder)) {
         context.report({message: "Objects with "+limit+" or more properties should have properties in alphabetical order. (Saw "+rawPropertyKeys.length+")", node: node});
       }
     }
     return {
+      "ExportNamedDeclaration": checkExport,
       "ObjectExpression": checkObject
     };
   }

--- a/lib/rules/alphabetize-properties.js
+++ b/lib/rules/alphabetize-properties.js
@@ -24,6 +24,12 @@ function extractName(exportSpecifier) {
   return exportSpecifier.local.name;
 }
 
+function checkOrderOfKeysIn(array) {
+  return function isKeyOutOfOrder(key, index) {
+    return index !== 0 && key < array[index-1];
+  };
+}
+
 module.exports = {
   esLintRuleName: "alphabetize-properties-of-large-objects",
   schema: [
@@ -62,11 +68,7 @@ module.exports = {
         return;
       }
       var exportNames = rawExportNames.filter(removeExemptions);
-      function isKeyOutOfOrder(key, index) {
-        // TODO control sorting order?
-        return index !== 0 && key < exportNames[index-1];
-      }
-      if (exportNames.find(isKeyOutOfOrder)) {
+      if (exportNames.find(checkOrderOfKeysIn(exportNames))) {
         context.report({message: "Exports with "+limit+" or more specifiers should have specifiers in alphabetical order. (Saw "+rawExportNames.length+")", node: node});
       }
     }
@@ -79,11 +81,7 @@ module.exports = {
         return;
       }
       var propertyKeys = rawPropertyKeys.filter(removeExemptions);
-      function isKeyOutOfOrder(key, index) {
-        // TODO control sorting order?
-        return index !== 0 && key < propertyKeys[index-1];
-      }
-      if (propertyKeys.find(isKeyOutOfOrder)) {
+      if (propertyKeys.find(checkOrderOfKeysIn(propertyKeys))) {
         context.report({message: "Objects with "+limit+" or more properties should have properties in alphabetical order. (Saw "+rawPropertyKeys.length+")", node: node});
       }
     }

--- a/lib/rules/alphabetize-properties.md
+++ b/lib/rules/alphabetize-properties.md
@@ -6,6 +6,8 @@ The specific limit of "how many properties is too many" is configurable. It defa
 
 Individual properties can also be named as being exempt from the alphabetization rule. This is to address a situation where a specific key should always occur first or last in an object, while keeping the remaining properties alphabetized.
 
+This rule applies to object literals as well as named exports.
+
 
 ## Rule Details
 
@@ -14,11 +16,13 @@ The following patterns are considered warnings:
 ```js
 /* eslint alphabetize-properties */
 obj = {z:z, a:a, b:b, c:c, d:d}
+export {z:z, a:a, b:b, c:c, d:d}
 ```
 
 ```js
 /* eslint alphabetize-properties: [2, {limit: 2}] */
 obj = {z:z, a:a}
+export {z:z, a:a}
 ```
 
 The following patterns are not considered warnings:
@@ -28,6 +32,7 @@ The following patterns are not considered warnings:
 obj = {}
 obj = {z:z, a:a}
 obj = {a:a, b:b, c:c, d:d, z:z}
+export {a:a, b:b, c:c, d:d, z:z}
 ```
 
 ```js
@@ -35,4 +40,5 @@ obj = {a:a, b:b, c:c, d:d, z:z}
 obj = {}
 obj = {z:z, a:a}
 obj = {a:a, b:b, c:c, d:d, z:z, mixins: [foo]}
+export {a:a, b:b, c:c, d:d, z:z, mixins: [foo]}
 ```

--- a/tests/lib/rules/alphabetize-properties.test.js
+++ b/tests/lib/rules/alphabetize-properties.test.js
@@ -6,6 +6,10 @@ var rule = require("../../../lib/rules/alphabetize-properties");
 testHelper.tester.run("alphabetize-properties", rule, {
 
   valid: [
+    "export {}",
+    "export {z, a}",
+    "export {a, b, c, d, z}",
+    {code: "export {a, z, y, b}", options: [{limit: 3, exempt: ["y", "z"]}]},
     "obj = {}",
     "obj = {z:z, a:a}",
     "obj = {a:a, b:b, c:c, d:d, z:z}",
@@ -15,6 +19,10 @@ testHelper.tester.run("alphabetize-properties", rule, {
   ],
 
   invalid: [
+    "export {z, a, b, c, d}",
+    ["export {z, a}", [{"limit": 2}]],
+    ["export {a, z, b}", [{limit: 3, exempt: ["a"]}]],
+    ["export {a, z, y, b}", [{limit: 3, exempt: ["a", "z"]}]],
     "obj = {z:z, a:a, b:b, c:c, d:d}",
     "obj = {...foo, z:z, a:a, b:b, c:c, d:d}",
     ["obj = {z:z, a:a}", [{"limit": 2}]],


### PR DESCRIPTION
The current implementation of alphabetize-properties does not look at the names of specifiers in an export statement. Let's make it report those as well.

`[FE-14]`