### PR TITLE
allow customization of `no-unauthorized-global-properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,9 @@ The initial release! (v1.0.0 and 1.0.1 lost to the sands of ~~time~~ tooling...)
 [1.1.1]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/1.1.1
 [1.2.0]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/1.2.0
 [1.3.0]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/1.3.0
-[1.4.0]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/1.4.0
-[1.4.1]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/1.4.1
-[1.4.3]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/1.4.3
+[1.4.0]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/v1.4.0
+[1.4.1]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/v1.4.1
+[1.4.3]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/v1.4.3
 [Greenkeeper.io]: https://greenkeeper.io
 [Keep a Changelog]: http://keepachangelog.com/
 [Semantic Versioning]: http://semver.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 
 ## [unreleased]
 
+### Added
+- New option `denied` for the `no-unauthorized-global-properties` rule
+
+### Updated
+- New version of `npm` used to generate package-lock file
+
 
 ## [1.4.3] (2021-11-03)
 
@@ -19,6 +25,8 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 ## 1.4.2 (2021-11-03)
 
 Deprecated / unpublished.
+
+The [Greenkeeper.io] integration was removed.
 
 
 ## [1.4.1] (2020-02-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning].
 
 
-## [unreleased]
+## [1.5.0] (2021-12-15)
 
 ### Added
 - New option `denied` for the `no-unauthorized-global-properties` rule
@@ -92,6 +92,7 @@ The initial release! (v1.0.0 and 1.0.1 lost to the sands of ~~time~~ tooling...)
 [1.4.0]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/v1.4.0
 [1.4.1]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/v1.4.1
 [1.4.3]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/v1.4.3
+[1.5.0]: https://github.com/bleacherreport/eslint-plugin-laws-of-the-game/releases/tag/v1.5.0
 [Greenkeeper.io]: https://greenkeeper.io
 [Keep a Changelog]: http://keepachangelog.com/
 [Semantic Versioning]: http://semver.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning].
 
 
-## [1.5.0] (2021-12-15)
+## [1.5.0] (2021-12-16)
 
 ### Added
 - New option `denied` for the `no-unauthorized-global-properties` rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog] and this project adheres to [Semantic Versioning].
 
 
+## [unreleased]
+
+
 ## [1.4.3] (2021-11-03)
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ This codebase attempts to follow [Semantic Versioning].
 1. **Merge.** One or more *approved* Pull Requests are merged to the `trunk` branch.
 1. **Test.** Ensure the test suite passes, and runs the expected number of tests: `npm test`
 1. **Measure.** Choose the appropriate New Version Number according to [Semantic Versioning]. (The `CHANGELOG.md` file may help with identifying the nature of the changes.)
-1. **Changelog.** Edit the `CHANGELOG.md` file, replacing the "Unreleased" label with the New Version Number, linked to the (as-yet-uncreated) GitHub tag as well (the pattern is `https://github.com/<user>/<repo>/releases/tag/<version-number>`). Ensure that the notes under this version reflect the changes made by the merged Pull Requests. Commit and push.
+1. **Changelog.** Edit the `CHANGELOG.md` file, replacing the "Unreleased" label with the New Version Number, linked to the (as-yet-uncreated) GitHub tag as well (the pattern is `https://github.com/<user>/<repo>/releases/tag/v<version-number>` note the `v`). Ensure that the notes under this version reflect the changes made by the merged Pull Requests. Commit and push.
 1. **Version.** Run `npm version <version-number> --message "Version %s"` to both update the version in the `package.json` file and create the tag on GitHub.
 1. **Publish.** Run `git push && npm publish` to push the merges & version to GitHub, and publish the new package on npmjs.com.
 1. **Release.** Create a new Release on GitHub. Visit `https://github.com/<user>/<repo>/releases`, click the "Draft a new release" button. In the Tag field, enter "v<version-number>"; in the Title field, enter just the version number; in the Description, write a brief description of the changes in this version. Then click "Publish release".
+
+More on the general patterns of publishing packages: ["How to Publish an Updated Version of an npm Package"]
 
 
 
@@ -112,3 +114,4 @@ This codebase attempts to follow [Semantic Versioning].
 [PillarsOfJS]: https://medium.com/javascript-scene/the-two-pillars-of-javascript-ee6f3281e7f3
 [Process-dot-env]: https://nodejs.org/api/process.html#process_process_env
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+["How to Publish an Updated Version of an npm Package"]: https://cloudfour.com/thinks/how-to-publish-an-updated-version-of-an-npm-package/

--- a/lib/rules/no-unauthorized-global-properties.js
+++ b/lib/rules/no-unauthorized-global-properties.js
@@ -256,14 +256,23 @@ module.exports = {
             "type": "string"
           },
           "uniqueItems": true
+        },
+
+        "denied": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
         }
       }
     }
   ],
   create: function(context) {
     var allowedProperties = determinePropertiesToAllow(context.options);
+    const deniedProperties = context.options && context.options[0] && context.options[0].denied || [];
     function checkMemberExpression(node) {
-      if (!allowedProperties.includes(node.property.name)) {
+      if (deniedProperties.includes(node.property.name) || !allowedProperties.includes(node.property.name)) {
         context.report({message: "Not permitted to access the "+node.property.name+" property of the `global` object.", node: node});
       }
     }

--- a/lib/rules/no-unauthorized-global-properties.md
+++ b/lib/rules/no-unauthorized-global-properties.md
@@ -10,47 +10,47 @@ It defaults to allowing the set of properties which are in the core JavaScript l
 The following patterns are considered warnings:
 
 ```js
-/* eslint no-unauthorized-global-properties: 2 */
+/* eslint no-unauthorized-global-properties: "error" */
 global.document;
 global.setImmediate();
 global.foo;
 ```
 
 ```js
-/* eslint no-unauthorized-global-properties: [2, {preset: "browser"}] */
+/* eslint no-unauthorized-global-properties: ["error", {preset: "browser"}] */
 global.setImmediate();
 ```
 
 ```js
-/* eslint no-unauthorized-global-properties: [2, {preset: "node"}] */
+/* eslint no-unauthorized-global-properties: ["error", {preset: "node"}] */
 global.document;
 ```
 
 ```js
-/* eslint no-unauthorized-global-properties: [2, {preset: "both"}] */
+/* eslint no-unauthorized-global-properties: ["error", {preset: "both"}] */
 global.foo;
 ```
 
 ```js
-/* eslint no-unauthorized-global-properties: [2, {permitted: ["foo", "bar"]}] */
+/* eslint no-unauthorized-global-properties: ["error", {permitted: ["foo", "bar"]}] */
 global.document;
 ```
 
 The following patterns are not considered warnings:
 
 ```js
-/* eslint no-unauthorized-global-properties: [2, {preset: ["browser"]}] */
+/* eslint no-unauthorized-global-properties: ["error", {preset: ["browser"]}] */
 global.document;
 ```
 
 ```js
-/* eslint no-unauthorized-global-properties: [2, {preset: "both"}] */
+/* eslint no-unauthorized-global-properties: ["error", {preset: "both"}] */
 global.document;
 global.setImmediate();
 ```
 
 ```js
-/* eslint no-unauthorized-global-properties: [2, {permitted: ["foo", "bar"], preset: "both"}] */
+/* eslint no-unauthorized-global-properties: ["error", {permitted: ["foo", "bar"], preset: "both"}] */
 global.document;
 global.setImmediate();
 global.bar;

--- a/lib/rules/no-unauthorized-global-properties.md
+++ b/lib/rules/no-unauthorized-global-properties.md
@@ -2,7 +2,7 @@
 
 This rule checks for the use of properties on the `global` object which are unrecognized.
 
-It defaults to allowing the set of properties which are in the core JavaScript language. It can be configured to additionally allow all properties available in browser context, Node context, or both, and allows further customization.
+It defaults to allowing the set of properties which are in the core JavaScript language. It can be configured to additionally allow all properties available in browser context, Node context, or both, and allows further customization (via `permitted` / `denied` lists).
 
 
 ## Rule Details
@@ -14,6 +14,11 @@ The following patterns are considered warnings:
 global.document;
 global.setImmediate();
 global.foo;
+```
+
+```js
+/* eslint no-unauthorized-global-properties: ["error", {preset: "browser", denied: ["document"]}] */
+global.document;
 ```
 
 ```js
@@ -39,7 +44,7 @@ global.document;
 The following patterns are not considered warnings:
 
 ```js
-/* eslint no-unauthorized-global-properties: ["error", {preset: ["browser"]}] */
+/* eslint no-unauthorized-global-properties: ["error", {preset: "browser"}] */
 global.document;
 ```
 

--- a/lib/rules/no-unauthorized-global-properties.md
+++ b/lib/rules/no-unauthorized-global-properties.md
@@ -1,8 +1,8 @@
-# Disallow using properties on the `global` object unless they are known-good, or explicitly permitted
+# Disallow the use of arbitrary properties on the `global` object
 
 This rule checks for the use of properties on the `global` object which are unrecognized.
 
-It defaults to allowing the set of properties which are in the core JavaScript language. It can be configured to additionally allow all properties available in browser context, Node context, or both, and also allows specifying a custom list of properties to allow use of.
+It defaults to allowing the set of properties which are in the core JavaScript language. It can be configured to additionally allow all properties available in browser context, Node context, or both, and allows further customization.
 
 
 ## Rule Details

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@br/eslint-plugin-laws-of-the-game",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@br/eslint-plugin-laws-of-the-game",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint-plugin-babel": "^5.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@br/eslint-plugin-laws-of-the-game",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@br/eslint-plugin-laws-of-the-game",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint-plugin-babel": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@br/eslint-plugin-laws-of-the-game",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Disincentivizes some coding practices.",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/no-unauthorized-global-properties.test.js
+++ b/tests/lib/rules/no-unauthorized-global-properties.test.js
@@ -20,11 +20,12 @@ testHelper.tester.run("no-unauthorized-global-properties", rule, {
     "global.setImmediate()",
     "global.foo",
     ["global.setImmediate()", [{preset: "browser"}]],
+    ["global.console", [{preset: "browser", denied: ["console"]}]],
     ["global.document", [{preset: "node"}]],
     ["global.addEventListener()", [{preset: "node"}]],
     ["global.foo", [{preset: "browser"}]],
     ["global.foo", [{preset: "both"}]],
     ["global.foo", [{permitted: ["bar"]}]]
-  ].map(testHelper.makeInvalidCase({message: /property/}))
+  ].map(testHelper.makeInvalidCase({message: /Not permitted .+ property .+ `global`/}))
 
 });


### PR DESCRIPTION
implements #17

Adds support for an option `denied` to the `no-unauthorized-global-properties` rule. This lets a user specify a subset of properties from a preset(s) which should not be permitted.